### PR TITLE
UI: Diagnostics Tab - Negative Number decrement fix

### DIFF
--- a/views/tools/diagnostics/logging.php
+++ b/views/tools/diagnostics/logging.php
@@ -115,7 +115,7 @@ jQuery(document).ready(function($)
 	function timer() {
 		count = count - 1;
 		$("#dup-refresh-count").html(count.toString());
-		if (! $("#dup-auto-refresh").is(":checked")) {
+		if (! $("#dup-auto-refresh").is(":checked") && count < 0) {
 			 clearInterval(timerInterval);
 			 $("#dup-refresh-count").text(count.toString().trim());
 			 return;


### PR DESCRIPTION
On the Diagnostics Tab, Logs secondary tab, there is a checkbox where you can click to 'Auto Refresh'. If you abuse this checkbox and click multiple times rapidly, the number will turn negative. This fix simply ensures that the number will never

turn negative and that on 0, the Package Log page will refresh